### PR TITLE
fix not deleted nan from _compose_alpha

### DIFF
--- a/blend_modes/blending_functions.py
+++ b/blend_modes/blending_functions.py
@@ -66,7 +66,7 @@ def _compose_alpha(img_in, img_layer, opacity):
     new_alpha = img_in[:, :, 3] + (1.0 - img_in[:, :, 3]) * comp_alpha
     np.seterr(divide='ignore', invalid='ignore')
     ratio = comp_alpha / new_alpha
-    ratio[ratio == np.NAN] = 0.0
+    ratio = np.nan_to_num(ratio)
     return ratio
 
 


### PR DESCRIPTION
Fix bug with not deleted nan. 
If you insert 
```
    ratio[ratio == np.NAN] = 0.0
    assert not np.isnan(ratio).any()
```
12 of 24 tests will be failed. 
`    ratio[ratio == np.NAN] = 0.0` doesn't delete nans? We should use `ratio = np.nan_to_num(ratio)` instead.