### PR TITLE
Fix np.NAN error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Blend Modes
 ===========
 This Python package implements blend modes for images.
 
+**⚠️ This project is no longer maintained. Are you interested in maintaining it? Please file let us know [here](https://github.com/flrs/blend_modes/issues/28). ⚠️**
+
 Description
 -----------
 The Blend Modes package enables blending different images, or image layers, by means of blend modes. These modes are commonly found in graphics programs like [Adobe Photoshop](http://www.adobe.com/Photoshop) or [GIMP](https://www.gimp.org/).

--- a/blend_modes/blending_functions.py
+++ b/blend_modes/blending_functions.py
@@ -66,7 +66,7 @@ def _compose_alpha(img_in, img_layer, opacity):
     new_alpha = img_in[:, :, 3] + (1.0 - img_in[:, :, 3]) * comp_alpha
     np.seterr(divide='ignore', invalid='ignore')
     ratio = comp_alpha / new_alpha
-    ratio[ratio == np.NAN] = 0.0
+    ratio[np.isnan(ratio)] = 0.0
     return ratio
 
 


### PR DESCRIPTION
Fix error in the [blending_functions.py](https://github.com/flrs/blend_modes/blob/master/blend_modes/blending_functions.py#L69) file (fixes [issue #29](https://github.com/flrs/blend_modes/issues/29))

```python
ratio[ratio == np.NAN] = 0.0
```

changed to:

```python
ratio[np.isnan(ratio)] = 0.0
```